### PR TITLE
Update `go get` link for cmdline app

### DIFF
--- a/cmd/json2go/README.md
+++ b/cmd/json2go/README.md
@@ -44,7 +44,7 @@ Struct tags with the key `json` are generated for all fields.  Additional struct
 
 Compile:
 
-    go get github.com/mohae/json2g0/cmd/json2go
+    go get github.com/mohae/json2go/cmd/json2go
 
 The compiled application will be placed in your `$GOPATH/bin/`.
 


### PR DESCRIPTION
Looks like `0` was used instead of `o`. Changed to `o` to reflect the url from Github.

Thanks for this tool :)