### PR TITLE
Fix missing error return

### DIFF
--- a/json2go.go
+++ b/json2go.go
@@ -220,6 +220,9 @@ DEFINE:
 		buff.Write(val)
 	}
 	fmtd, err := format.Source(buff.Bytes())
+	if err != nil {
+		return err
+	}
 	n, err = t.w.Write(fmtd)
 	if err != nil {
 		return err

--- a/json2go.go
+++ b/json2go.go
@@ -120,26 +120,14 @@ func (t *Transmogrifier) SetTagKeys(v []string) error {
 // Gen generates the struct definitions and outputs it to W.
 func (t *Transmogrifier) Gen() error {
 	var buff bytes.Buffer
-	b := make([]byte, 1024)
-	for {
-		n, err := t.r.Read(b)
-		if err != nil && err != io.EOF {
-			return err
-		}
-		if n == 0 {
-			break
-		}
-		m, err := buff.Write(b[:n])
-		if err != nil {
-			return err
-		}
-		if n != m {
-			return ShortWriteError{n: n, written: m, operation: "JSON to buffer"}
-		}
+	_, err := buff.ReadFrom(t.r)
+	if err != nil {
+		return err
 	}
 	if t.WriteJSON {
 		// TODO marshal indent
-		n, err := t.jw.Write(buff.Bytes())
+		var n int
+		n, err = t.jw.Write(buff.Bytes())
 		if err != nil {
 			return err
 		}
@@ -148,7 +136,7 @@ func (t *Transmogrifier) Gen() error {
 		}
 	}
 	var def interface{}
-	err := json.Unmarshal(buff.Bytes(), &def)
+	err = json.Unmarshal(buff.Bytes(), &def)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This causes json2go to exit with no error if the generated output is syntactically incorrect.

e.g, this would produce no output:

```
curl https://d3teyb21fexa9r.cloudfront.net/latest/CloudFormationResourceSpecification.json | json2go -n foo
```

With this patch, json2go (resonably) produces:

```
14:5: expected ';', found ':' (and 10 more errors)
```

8e9c262 also simplifies the implementation in a trivial way by avoiding writing
 the buffer copy loop explicitly and using `buff.ReadFrom()` instead.