### PR TITLE
feat: add string tag & json.Number

### DIFF
--- a/cmd/json2go/main.go
+++ b/cmd/json2go/main.go
@@ -78,6 +78,7 @@ var (
 	mapType    bool
 	help       bool
 	tagKeys    stringArr
+	stringTag  bool
 )
 
 func init() {
@@ -101,6 +102,8 @@ func init() {
 	flag.BoolVar(&help, "h", false, "the short flag for -help")
 	flag.Var(&tagKeys, "tagkeys", "additional struct tag keys; can be used more than once")
 	flag.Var(&tagKeys, "t", "the short flag for -tagkeys")
+	flag.BoolVar(&stringTag, "stringtag", false, "add `,string` after tag if the string type field can be parsed as a Int/Float value.")
+	flag.BoolVar(&stringTag, "S", false, "the short flag for -guess")
 }
 
 func main() {
@@ -196,8 +199,10 @@ func realMain() int {
 		t.SetPkg(pkg)
 	}
 	t.MapType = mapType
+	t.StringTag = stringTag
 	t.SetStructName(structName)
 	t.SetTagKeys(tagKeys.Get())
+
 	// Generate the Go Types
 	err = t.Gen()
 	if err != nil {
@@ -254,6 +259,8 @@ flag              default   description
 -h  -help         false     Print the help text; 'help' is also valid.
 -t  -tagkey                 Additional key to be added to struct tags.
                             For multiple keys, use one per key value.
+-S  -stringtag    false     Add ',string' to tags which could be parsed
+                            as a number type.
 `
 	fmt.Println(helpText)
 }

--- a/json2go_test.go
+++ b/json2go_test.go
@@ -444,10 +444,28 @@ func TestEmptySlice(t *testing.T) {
 	var buff bytes.Buffer
 	calvin := NewTransmogrifier("test", r, &buff)
 	err := calvin.Gen()
-	if err !=  nil {
+	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
-	if buff.String () != expected {
+	if buff.String() != expected {
+		t.Errorf("got %q want %q", buff.String(), expected)
+	}
+}
+
+func TestStringTag(t *testing.T) {
+	test := `{"aaa":"123","bbb":"123.123","test":9223372036854775807,"test1":"123,123"}`
+
+	expected := "package main\n\ntype Test struct {\n\tAaa   int     `json:\"aaa,string\"`\n\tBbb   float64 `json:\"bbb,string\"`\n\tTest  int     `json:\"test\"`\n\tTest1 string  `json:\"test1\"`\n}\n"
+
+	r := bytes.NewReader([]byte(test))
+	var buff bytes.Buffer
+	calvin := NewTransmogrifier("test", r, &buff)
+	calvin.StringTag = true
+	err := calvin.Gen()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if buff.String() != expected {
 		t.Errorf("got %q want %q", buff.String(), expected)
 	}
 }


### PR DESCRIPTION
# feat: add string tag & json.Number

Hello, here are two functional changes. Thanks for reviewing it.

- Add a new cmd option `-S -stringtag`. Allow users to let our tool to try to add a `,string` tag into string type fields that look like numbers.
- Use `json.Number` interface to determine whether the field is a float or an integer.

And I wrote a test function for example. Do you think there is anything else I should add? I would be gladly to add them. 
:)